### PR TITLE
Max 25.2.0 support

### DIFF
--- a/linux_raw/utils.mojo
+++ b/linux_raw/utils.mojo
@@ -1,11 +1,11 @@
-from sys import has_neon
-from sys.info import is_x86, is_64bit
+from sys import has_neon, CompilationTarget
+from sys.info import is_64bit
 from memory import UnsafePointer
 
 
 @always_inline("nodebug")
 fn is_x86_64() -> Bool:
-    return is_x86() and is_64bit()
+    return CompilationTarget.is_x86() and is_64bit()
 
 
 @value

--- a/linux_raw/utils.mojo
+++ b/linux_raw/utils.mojo
@@ -1,11 +1,11 @@
-from sys import has_neon, CompilationTarget
-from sys.info import is_64bit
+from sys import has_neon
+from sys.info import is_64bit, is_x86
 from memory import UnsafePointer
 
 
 @always_inline("nodebug")
 fn is_x86_64() -> Bool:
-    return CompilationTarget.is_x86() and is_64bit()
+    return is_x86() and is_64bit()
 
 
 @value

--- a/mojix/io_uring.mojo
+++ b/mojix/io_uring.mojo
@@ -170,9 +170,9 @@ alias SQE128 = SQE(
 @register_passable("trivial")
 struct SQE:
     var id: UInt8
-    var size: IntLiteral
-    var align: IntLiteral
-    var array_size: IntLiteral
+    var size: Int
+    var align: Int
+    var array_size: Int
     var setup_flags: IoUringSetupFlags
 
     @always_inline
@@ -223,10 +223,10 @@ alias CQE_SIZE_MAX = CQE32.size
 @register_passable("trivial")
 struct CQE:
     var id: UInt8
-    var size: IntLiteral
-    var align: IntLiteral
-    var array_size: IntLiteral
-    var rings_size: IntLiteral
+    var size: Int
+    var align: Int
+    var array_size: Int
+    var rings_size: Int
     """For the size of the rings, we perform calculations in the same way as the kernel.
     [Linux]: https://github.com/torvalds/linux/blob/v6.7/io_uring/io_uring.c#L2804.
     [Linux]: https://github.com/torvalds/linux/blob/v6.7/include/linux/io_uring_types.h#L83.
@@ -660,7 +660,7 @@ struct IoUringCqeFlags(Defaultable, Boolable):
         return self.value != 0
 
     @always_inline("nodebug")
-    fn __rshift__(self, rhs: IntLiteral) -> Self:
+    fn __rshift__(self, rhs: Int) -> Self:
         """Returns `self >> rhs`.
 
         Args:

--- a/mojix/utils.mojo
+++ b/mojix/utils.mojo
@@ -22,7 +22,7 @@ fn _size_eq[T: AnyType, I: AnyType]():
 
 
 @always_inline("nodebug")
-fn _size_eq[T: AnyType, size: IntLiteral]():
+fn _size_eq[T: AnyType, size: Int]():
     constrained[sizeof[T]() == size]()
 
 
@@ -32,7 +32,7 @@ fn _align_eq[T: AnyType, I: AnyType]():
 
 
 @always_inline("nodebug")
-fn _align_eq[T: AnyType, align: IntLiteral]():
+fn _align_eq[T: AnyType, align: Int]():
     constrained[alignof[T]() == align]()
 
 

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -1,6 +1,6 @@
 [project]
 authors = ["Dmitry Salin <dmitry.salin@gmail.com>"]
-channels = ["conda-forge", "https://conda.modular.com/max-nightly"]
+channels = ["conda-forge", "https://conda.modular.com/max"]
 description = "The low-level `io_uring` userspace interface"
 name = "io_uring"
 platforms = ["linux-64"]
@@ -9,4 +9,4 @@ version = "0.1.0"
 [tasks]
 
 [dependencies]
-max = "*"
+max = ">=25.2.0"

--- a/mojoproject.toml
+++ b/mojoproject.toml
@@ -1,6 +1,6 @@
 [project]
 authors = ["Dmitry Salin <dmitry.salin@gmail.com>"]
-channels = ["conda-forge", "https://conda.modular.com/max"]
+channels = ["conda-forge", "https://conda.modular.com/max-nightly"]
 description = "The low-level `io_uring` userspace interface"
 name = "io_uring"
 platforms = ["linux-64"]
@@ -9,4 +9,4 @@ version = "0.1.0"
 [tasks]
 
 [dependencies]
-max = "==25.1.1"
+max = "*"


### PR DESCRIPTION
Support for the new Max 25.2.0.

See announcement: https://www.modular.com/blog/max-25-2-unleash-the-power-of-your-h200s-without-cuda